### PR TITLE
COBRA-2183-ui-feedback

### DIFF
--- a/src/components/Addons/index.jsx
+++ b/src/components/Addons/index.jsx
@@ -154,7 +154,7 @@ export default class Addons extends Component {
           className="addon-remove"
           onClick={() => this.handleAddonConfirmation(addon)}
         >
-          <RemoveIcon color={(!isElevated || addon.state === 'provisioning') ? 'disabled' : 'inherit'} />
+          <RemoveIcon color={((restrictedSpace && !isElevated) || addon.state === 'provisioning') ? 'disabled' : 'inherit'} />
         </IconButton>
       );
 
@@ -193,20 +193,20 @@ export default class Addons extends Component {
   getAddonAttachments() {
     const { isElevated, restrictedSpace } = this.state;
     return this.state.addonAttachments.map((attachment, index) => {
-      let deleteButton;
-      if (!restrictedSpace || isElevated) {
-        deleteButton = (
-          <IconButton
-            disabled={!isElevated || attachment.state === 'provisioning'}
-            style={style.iconButton}
-            className="attachment-remove"
-            onClick={() => this.handleAddonAttachmentConfirmation(attachment)}
-          >
-            <RemoveIcon color={(!isElevated || attachment.state === 'provisioning') ? 'disabled' : 'inherit'} />
-          </IconButton>
-        );
-      } else {
-        // Wrap the delete button in a tooltip to avoid confusion as to why it is disabled
+      let deleteButton = (
+        <IconButton
+          disabled={(restrictedSpace && !isElevated) || attachment.state === 'provisioning'}
+          style={style.iconButton}
+          className="addon-remove"
+          onClick={() => this.handleAddonAttachmentConfirmation(attachment)}
+        >
+          <RemoveIcon color={((restrictedSpace && !isElevated) || attachment.state === 'provisioning') ? 'disabled' : 'inherit'} />
+        </IconButton>
+      );
+
+      // Wrap the delete button in a tooltip to avoid confusion as to why it is disabled
+      if (restrictedSpace && !isElevated) {
+        // Wrap the delete controls in a tooltip to avoid confusion as to why they are disabled
         deleteButton = addRestrictedTooltip('Elevated access required', 'right', deleteButton);
       }
 

--- a/src/components/Addons/index.jsx
+++ b/src/components/Addons/index.jsx
@@ -115,6 +115,7 @@ export default class Addons extends Component {
       currentAddon: {},
       addonDialogOpen: false,
       isElevated: false,
+      restrictedSpace: false,
     };
     this.loadAddons();
   }
@@ -129,24 +130,26 @@ export default class Addons extends Component {
     // There is still an API call on the backend that controls access to the actual
     // deletion of the addon, this is merely for convienence.
 
-    let isElevated = true;
+    let isElevated = false;
+    let restrictedSpace = false;
     if (app.space.compliance.includes('prod') || app.space.compliance.includes('socs')) {
       // If we don't have the elevated_access object in the accountInfo object,
       // default to enabling the button (access will be controlled on the API)
       isElevated = accountInfo.elevated_access ? accountInfo.elevated_access : true;
+      restrictedSpace = true;
     }
-    this.setState({ isElevated }); // eslint-disable-line react/no-did-mount-set-state
+    this.setState({ isElevated, restrictedSpace }); // eslint-disable-line react/no-did-mount-set-state
   }
   componentWillUnmount() {
     this._isMounted = false;
   }
 
   getAddons() {
-    const { isElevated } = this.state;
+    const { isElevated, restrictedSpace } = this.state;
     return this.state.addons.map((addon) => {
       let deleteButton = (
         <IconButton
-          disabled={!isElevated || addon.state === 'provisioning'}
+          disabled={(restrictedSpace && !isElevated) || addon.state === 'provisioning'}
           style={style.iconButton}
           className="addon-remove"
           onClick={() => this.handleAddonConfirmation(addon)}
@@ -154,10 +157,13 @@ export default class Addons extends Component {
           <RemoveIcon color={(!isElevated || addon.state === 'provisioning') ? 'disabled' : 'inherit'} />
         </IconButton>
       );
-      if (!isElevated) {
+
+      // Wrap the delete button in a tooltip to avoid confusion as to why it is disabled
+      if (restrictedSpace && !isElevated) {
         // Wrap the delete controls in a tooltip to avoid confusion as to why they are disabled
         deleteButton = addRestrictedTooltip('Elevated access required', 'right', deleteButton);
       }
+
       return (
         <TableRow
           hover
@@ -185,22 +191,25 @@ export default class Addons extends Component {
   }
 
   getAddonAttachments() {
-    const { isElevated } = this.state;
+    const { isElevated, restrictedSpace } = this.state;
     return this.state.addonAttachments.map((attachment, index) => {
-      let deleteButton = (
-        <IconButton
-          disabled={!isElevated || attachment.state === 'provisioning'}
-          style={style.iconButton}
-          className="attachment-remove"
-          onClick={() => this.handleAddonAttachmentConfirmation(attachment)}
-        >
-          <RemoveIcon color={(!isElevated || attachment.state === 'provisioning') ? 'disabled' : 'inherit'} />
-        </IconButton>
-      );
-      if (!isElevated) {
+      let deleteButton;
+      if (!restrictedSpace || isElevated) {
+        deleteButton = (
+          <IconButton
+            disabled={!isElevated || attachment.state === 'provisioning'}
+            style={style.iconButton}
+            className="attachment-remove"
+            onClick={() => this.handleAddonAttachmentConfirmation(attachment)}
+          >
+            <RemoveIcon color={(!isElevated || attachment.state === 'provisioning') ? 'disabled' : 'inherit'} />
+          </IconButton>
+        );
+      } else {
         // Wrap the delete button in a tooltip to avoid confusion as to why it is disabled
         deleteButton = addRestrictedTooltip('Elevated access required', 'right', deleteButton);
       }
+
       return (
         <TableRow
           hover

--- a/src/components/Addons/index.jsx
+++ b/src/components/Addons/index.jsx
@@ -23,6 +23,14 @@ function isEmpty(obj) {
   return empty;
 }
 
+function addRestrictedTooltip(title, placement, children) {
+  return (
+    <Tooltip title={title} placement={placement}>
+      <div style={{ opacity: 0.35 }}>{children}</div>
+    </Tooltip>
+  );
+}
+
 const muiTheme = createMuiTheme({
   palette: {
     primary: { main: '#0097a7' },
@@ -66,9 +74,6 @@ const style = {
       fontSize: '11px',
       textTransform: 'uppercase',
     },
-    end: {
-      float: 'right',
-    },
     icon: {
       width: '58px',
     },
@@ -109,84 +114,122 @@ export default class Addons extends Component {
       attachmentsLoaded: false,
       currentAddon: {},
       addonDialogOpen: false,
+      isElevated: false,
     };
     this.loadAddons();
   }
 
   componentDidMount() {
     this._isMounted = true;
+    const { app, accountInfo } = this.props;
+
+    // If this is a production app, check for the elevated_access role to determine
+    // whether or not to enable the delete addon button.
+
+    // There is still an API call on the backend that controls access to the actual
+    // deletion of the addon, this is merely for convienence.
+
+    let isElevated = false;
+    if (app.space.compliance.includes('prod') || app.space.compliance.includes('socs')) {
+      // If we don't have the elevated_access object in the accountInfo object,
+      // default to enabling the button (access will be controlled on the API)
+      isElevated = accountInfo.elevated_access ? accountInfo.elevated_access : true;
+    }
+    this.setState({ isElevated }); // eslint-disable-line react/no-did-mount-set-state
   }
   componentWillUnmount() {
     this._isMounted = false;
   }
 
   getAddons() {
-    return this.state.addons.map(addon => (
-      <TableRow
-        hover
-        className={addon.addon_service.name}
-        key={addon.id}
-        style={style.tableRowPointer}
-      >
-        <TableCell
-          onClick={() => this.setState({ currentAddon: addon, addonDialogOpen: true })}
+    const { isElevated } = this.state;
+    return this.state.addons.map((addon) => {
+      let deleteButton = (
+        <IconButton
+          disabled={!isElevated || addon.state === 'provisioning'}
+          style={style.iconButton}
+          className="addon-remove"
+          onClick={() => this.handleAddonConfirmation(addon)}
         >
-          <div style={style.tableRowColumn.title}>{addon.addon_service.name}</div>
-          <div style={style.tableRowColumn.sub}>{addon.id} {addon.state === 'provisioning' ? '- provisioning' : ''}</div>
-        </TableCell>
-        <TableCell
-          onClick={() => this.setState({ currentAddon: addon, addonDialogOpen: true })}
+          <RemoveIcon color={(!isElevated || addon.state === 'provisioning') ? 'disabled' : 'inherit'} />
+        </IconButton>
+      );
+      if (!isElevated) {
+        // Wrap the delete controls in a tooltip to avoid confusion as to why they are disabled
+        deleteButton = addRestrictedTooltip('Elevated access required', 'right', deleteButton);
+      }
+      return (
+        <TableRow
+          hover
+          className={addon.addon_service.name}
+          key={addon.id}
+          style={style.tableRowPointer}
         >
-          <div style={style.tableRowColumn.title}>{addon.plan.name}</div>
-        </TableCell>
-        <TableCell style={style.tableRowColumn.icon}>
-          <div style={style.tableRowColumn.end}>
-            <IconButton 
-              disabled={addon.state === 'provisioning' ? true : false} 
-              style={style.iconButton} 
-              className="addon-remove" 
-              onClick={() => this.handleAddonConfirmation(addon)}>
-                <RemoveIcon color={addon.state === 'provisioning' ? 'disabled' : 'inherit'} />
-            </IconButton>
-          </div>
-        </TableCell>
-      </TableRow>
-    ));
+          <TableCell
+            onClick={() => this.setState({ currentAddon: addon, addonDialogOpen: true })}
+          >
+            <div style={style.tableRowColumn.title}>{addon.addon_service.name}</div>
+            <div style={style.tableRowColumn.sub}>{addon.id} {addon.state === 'provisioning' ? '- provisioning' : ''}</div>
+          </TableCell>
+          <TableCell
+            onClick={() => this.setState({ currentAddon: addon, addonDialogOpen: true })}
+          >
+            <div style={style.tableRowColumn.title}>{addon.plan.name}</div>
+          </TableCell>
+          <TableCell style={style.tableRowColumn.icon}>
+            {deleteButton}
+          </TableCell>
+        </TableRow>
+      );
+    });
   }
 
   getAddonAttachments() {
-    return this.state.addonAttachments.map((attachment, index) => (
-      <TableRow
-        hover
-        className={`${attachment.name} addon-attachment-list-${index}`}
-        key={attachment.id}
-        style={style.tableRowPointer}
-      >
-        <TableCell
-          onClick={() => this.setState({ currentAddon: attachment, addonDialogOpen: true })}
+    const { isElevated } = this.state;
+    return this.state.addonAttachments.map((attachment, index) => {
+      let deleteButton = (
+        <IconButton
+          disabled={!isElevated || attachment.state === 'provisioning'}
+          style={style.iconButton}
+          className="attachment-remove"
+          onClick={() => this.handleAddonAttachmentConfirmation(attachment)}
         >
-          <div style={style.tableRowColumn.title}>{attachment.name}</div>
-          <div style={style.tableRowColumn.sub}>{attachment.id} {attachment.state === 'provisioning' ? '- provisioning' : ''}</div>
-        </TableCell>
-        <TableCell
-          onClick={() => this.setState({ currentAddon: attachment, addonDialogOpen: true })}
+          <RemoveIcon color={(!isElevated || attachment.state === 'provisioning') ? 'disabled' : 'inherit'} />
+        </IconButton>
+      );
+      if (!isElevated) {
+        // Wrap the delete button in a tooltip to avoid confusion as to why it is disabled
+        deleteButton = addRestrictedTooltip('Elevated access required', 'right', deleteButton);
+      }
+      return (
+        <TableRow
+          hover
+          className={`${attachment.name} addon-attachment-list-${index}`}
+          key={attachment.id}
+          style={style.tableRowPointer}
         >
-          <div style={style.tableRowColumn.title}>{attachment.addon.plan.name}</div>
-        </TableCell>
-        <TableCell
-          onClick={() => this.setState({ currentAddon: attachment, addonDialogOpen: true })}
-        >
-          <div style={style.tableRowColumn.title}>{attachment.addon.app.name}</div>
-        </TableCell>
-        <TableCell style={style.tableRowColumn.icon}>
-          <div style={style.tableRowColumn.end}>
-            <IconButton disabled={attachment.state === 'provisioning' ? true : false} style={style.iconButton} className="attachment-remove" onClick={() => this.handleAddonAttachmentConfirmation(attachment)}>
-              <RemoveIcon color={attachment.state === 'provisioning' ? 'disabled' : 'inherit'} />
-            </IconButton>
-          </div>
-        </TableCell>
-      </TableRow>
-    ));
+          <TableCell
+            onClick={() => this.setState({ currentAddon: attachment, addonDialogOpen: true })}
+          >
+            <div style={style.tableRowColumn.title}>{attachment.name}</div>
+            <div style={style.tableRowColumn.sub}>{attachment.id} {attachment.state === 'provisioning' ? '- provisioning' : ''}</div>
+          </TableCell>
+          <TableCell
+            onClick={() => this.setState({ currentAddon: attachment, addonDialogOpen: true })}
+          >
+            <div style={style.tableRowColumn.title}>{attachment.addon.plan.name}</div>
+          </TableCell>
+          <TableCell
+            onClick={() => this.setState({ currentAddon: attachment, addonDialogOpen: true })}
+          >
+            <div style={style.tableRowColumn.title}>{attachment.addon.app.name}</div>
+          </TableCell>
+          <TableCell style={style.tableRowColumn.icon}>
+            {deleteButton}
+          </TableCell>
+        </TableRow>
+      );
+    });
   }
 
   getDialogTitle() {
@@ -208,7 +251,7 @@ export default class Addons extends Component {
   getAppsAttachedToAddon() {
     const addons = this.state.addons;
     addons.forEach((addon, index) => {
-      api.getAppsAttachedToAddon(this.props.app, addon.id).then((res) => {
+      api.getAppsAttachedToAddon(this.props.app.name, addon.id).then((res) => {
         addons[index].attached_to = res.data.attached_to;
         if (addons.every(a => (a.attached_to))) {
           if (this._isMounted) {
@@ -220,7 +263,7 @@ export default class Addons extends Component {
 
     const addonAttachments = this.state.addonAttachments;
     addonAttachments.forEach((attachment, index) => {
-      api.getAppsAttachedToAddon(this.props.app, attachment.addon.id).then((res) => {
+      api.getAppsAttachedToAddon(this.props.app.name, attachment.addon.id).then((res) => {
         addonAttachments[index].attached_to = res.data.attached_to;
         if (addonAttachments.every(a => (a.attached_to))) {
           if (this._isMounted) {
@@ -233,8 +276,8 @@ export default class Addons extends Component {
 
   loadAddons() {
     Promise.all([
-      api.getAppAddons(this.props.app),
-      api.getAddonAttachments(this.props.app),
+      api.getAppAddons(this.props.app.name),
+      api.getAddonAttachments(this.props.app.name),
     ]).then(([r1, r2]) => {
       if (this._isMounted) {
         this.setState({
@@ -285,7 +328,7 @@ export default class Addons extends Component {
 
   handleRemoveAddon = () => {
     this.setState({ loading: true });
-    api.deleteAddon(this.props.app, this.state.addon.id).then(() => {
+    api.deleteAddon(this.props.app.name, this.state.addon.id).then(() => {
       this.reload('Addon Deleted');
     }).catch((error) => {
       this.setState({
@@ -302,7 +345,7 @@ export default class Addons extends Component {
 
   handleRemoveAddonAttachment = () => {
     this.setState({ loading: true });
-    api.deleteAddonAttachment(this.props.app, this.state.attachment.id).then(() => {
+    api.deleteAddonAttachment(this.props.app.name, this.state.attachment.id).then(() => {
       this.reload('Attachment Deleted');
     }).catch((error) => {
       this.setState({
@@ -356,8 +399,8 @@ export default class Addons extends Component {
   reload = (message) => {
     this.setState({ loading: true });
     Promise.all([
-      api.getAppAddons(this.props.app),
-      api.getAddonAttachments(this.props.app),
+      api.getAppAddons(this.props.app.name),
+      api.getAddonAttachments(this.props.app.name),
     ]).then(([r1, r2]) => {
       this.setState({
         addons: r1.data,
@@ -412,13 +455,13 @@ export default class Addons extends Component {
           {this.state.new && (
             <div>
               <IconButton style={style.iconButton} className="addon-cancel" onClick={this.handleNewAddonCancel}><RemoveIcon /></IconButton>
-              <NewAddon app={this.props.app} onComplete={this.reload} />
+              <NewAddon app={this.props.app.name} onComplete={this.reload} />
             </div>
           )}
           {this.state.attach && (
             <div>
               <IconButton style={style.iconButton} className="attach-cancel" onClick={this.handleAttachAddonCancel}><RemoveIcon /></IconButton>
-              <AttachAddon app={this.props.app} onComplete={this.reload} />
+              <AttachAddon app={this.props.app.name} onComplete={this.reload} />
             </div>
           )}
           <Table className="addon-list">
@@ -531,5 +574,6 @@ export default class Addons extends Component {
 }
 
 Addons.propTypes = {
-  app: PropTypes.string.isRequired,
+  app: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  accountInfo: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 };

--- a/src/components/Addons/index.jsx
+++ b/src/components/Addons/index.jsx
@@ -129,7 +129,7 @@ export default class Addons extends Component {
     // There is still an API call on the backend that controls access to the actual
     // deletion of the addon, this is merely for convienence.
 
-    let isElevated = false;
+    let isElevated = true;
     if (app.space.compliance.includes('prod') || app.space.compliance.includes('socs')) {
       // If we don't have the elevated_access object in the accountInfo object,
       // default to enabling the button (access will be controlled on the API)

--- a/src/components/Addons/index.jsx
+++ b/src/components/Addons/index.jsx
@@ -197,7 +197,7 @@ export default class Addons extends Component {
         <IconButton
           disabled={(restrictedSpace && !isElevated) || attachment.state === 'provisioning'}
           style={style.iconButton}
-          className="addon-remove"
+          className="attachment-remove"
           onClick={() => this.handleAddonAttachmentConfirmation(attachment)}
         >
           <RemoveIcon color={((restrictedSpace && !isElevated) || attachment.state === 'provisioning') ? 'disabled' : 'inherit'} />

--- a/src/components/Apps/AppOverview.jsx
+++ b/src/components/Apps/AppOverview.jsx
@@ -5,7 +5,7 @@ import {
   CircularProgress, Switch, List, ListItem, ListItemText, Button, Dialog,
   GridList, GridListTile, Table, TableBody, TableRow, TableCell,
   DialogActions, DialogContent, DialogContentText,
-  FormGroup, FormControlLabel,
+  FormGroup, FormControlLabel, Tooltip,
 } from '@material-ui/core';
 import RemoveIcon from '@material-ui/icons/Clear';
 
@@ -106,13 +106,30 @@ class AppOverview extends Component {
       submitFail: false,
       submitMessage: '',
       isMaintenance: false,
+      deleteDisabled: false,
     };
   }
 
   componentWillMount() {
+    const { app, accountInfo } = this.props;
+
+    // If this is a production app, check for the elevated_access role to determine
+    // whether or not to enable the delete app button.
+
+    // There is still an API call on the backend that controls access to the actual
+    // deletion of the app, this is merely for convienence.
+
+    let deleteDisabled = false;
+    if (app.space.compliance.includes('prod')) {
+      // If we don't have the elevated_access object in the accountInfo object,
+      // default to enabling the button (access will be controlled on the API)
+      deleteDisabled = accountInfo.elevated_access ? accountInfo.elevated_access : false;
+    }
+
     this.setState({ // eslint-disable-line react/no-did-mount-set-state
-      isMaintenance: this.props.app.maintenance,
+      isMaintenance: app.maintenance,
       loading: false,
+      deleteDisabled,
     });
   }
 
@@ -170,6 +187,7 @@ class AppOverview extends Component {
   }
 
   render() {
+    const { deleteDisabled } = this.state;
     if (this.state.loading) {
       return (
         <MuiThemeProvider theme={muiTheme}>
@@ -179,6 +197,29 @@ class AppOverview extends Component {
         </MuiThemeProvider>
       );
     }
+
+    let deleteButton = (
+      <Button
+        variant="contained"
+        className="delete"
+        style={style.button}
+        onClick={this.handleConfirmation}
+        color="secondary"
+        disabled={deleteDisabled}
+      >
+        <RemoveIcon style={style.removeIcon} nativeColor={deleteDisabled ? undefined : 'white'} />
+        <span style={style.deleteButtonLabel}>Delete App</span>
+      </Button>
+    );
+    // Wrap the delete button in a tooltip to avoid confusion as to why the button is disabled
+    if (deleteDisabled) {
+      deleteButton = (
+        <Tooltip title="Elevated access required" placement="top">
+          <div>{deleteButton}</div>
+        </Tooltip>
+      );
+    }
+
     return (
       <MuiThemeProvider theme={muiTheme}>
         <div>
@@ -241,12 +282,7 @@ class AppOverview extends Component {
                   </FormGroup>
                 </TableCell>
                 <TableCell >
-                  <div style={style.tableCell.end}>
-                    <Button variant="contained" className="delete" style={style.button} onClick={this.handleConfirmation} color="secondary">
-                      <RemoveIcon nativeColor="white" style={style.removeIcon} />
-                      <span style={style.deleteButtonLabel}>Delete App</span>
-                    </Button>
-                  </div>
+                  <div style={style.tableCell.end}>{deleteButton}</div>
                 </TableCell>
               </TableRow>
             </TableBody>
@@ -284,6 +320,7 @@ class AppOverview extends Component {
 AppOverview.propTypes = {
   app: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   onComplete: PropTypes.func.isRequired,
+  accountInfo: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 };
 
 export default AppOverview;

--- a/src/components/Apps/AppOverview.jsx
+++ b/src/components/Apps/AppOverview.jsx
@@ -115,6 +115,7 @@ class AppOverview extends Component {
       submitMessage: '',
       isMaintenance: false,
       isElevated: false,
+      restrictedSpace: false,
     };
   }
 
@@ -127,17 +128,20 @@ class AppOverview extends Component {
     // There is still an API call on the backend that controls access to the actual
     // deletion of the app, this is merely for convienence.
 
-    let isElevated = true;
+    let isElevated = false;
+    let restrictedSpace = false;
     if (app.space.compliance.includes('prod') || app.space.compliance.includes('socs')) {
       // If we don't have the elevated_access object in the accountInfo object,
       // default to enabling the button (access will be controlled on the API)
       isElevated = accountInfo.elevated_access ? accountInfo.elevated_access : true;
+      restrictedSpace = true;
     }
 
     this.setState({ // eslint-disable-line react/no-did-mount-set-state
       isMaintenance: app.maintenance,
       loading: false,
       isElevated,
+      restrictedSpace,
     });
   }
 
@@ -195,7 +199,7 @@ class AppOverview extends Component {
   }
 
   render() {
-    const { isElevated } = this.state;
+    const { isElevated, restrictedSpace } = this.state;
     if (this.state.loading) {
       return (
         <MuiThemeProvider theme={muiTheme}>
@@ -213,7 +217,7 @@ class AppOverview extends Component {
         style={style.button}
         onClick={this.handleConfirmation}
         color="secondary"
-        disabled={!isElevated}
+        disabled={(restrictedSpace && !isElevated)}
       >
         <RemoveIcon style={style.removeIcon} nativeColor={isElevated ? 'white' : undefined} />
         <span style={style.deleteButtonLabel}>Delete App</span>
@@ -221,7 +225,7 @@ class AppOverview extends Component {
     );
 
     // Wrap the delete button in a tooltip to avoid confusion as to why it is disabled
-    if (!isElevated) {
+    if (restrictedSpace && !isElevated) {
       deleteButton = addRestrictedTooltip('Elevated access required', deleteButton);
     }
 

--- a/src/components/Apps/AppOverview.jsx
+++ b/src/components/Apps/AppOverview.jsx
@@ -127,7 +127,7 @@ class AppOverview extends Component {
     // There is still an API call on the backend that controls access to the actual
     // deletion of the app, this is merely for convienence.
 
-    let isElevated = false;
+    let isElevated = true;
     if (app.space.compliance.includes('prod') || app.space.compliance.includes('socs')) {
       // If we don't have the elevated_access object in the accountInfo object,
       // default to enabling the button (access will be controlled on the API)

--- a/src/components/Audits/index.jsx
+++ b/src/components/Audits/index.jsx
@@ -95,7 +95,6 @@ export default class Audits extends Component {
         audits: response.data,
         loading: false,
       });
-      console.log(response.data);
     });
   }
 

--- a/src/components/Releases/index.jsx
+++ b/src/components/Releases/index.jsx
@@ -24,6 +24,14 @@ import NewAutoBuild from './NewAutoBuild';
 
 import AutoBuildIcon from '../Icons/GitIcon';
 
+function addRestrictedTooltip(title, placement, children) {
+  return (
+    <Tooltip title={title} placement={placement}>
+      <div style={{ display: 'inline' }}>{children}</div>
+    </Tooltip>
+  );
+}
+
 const muiTheme = createMuiTheme({
   palette: {
     primary: { main: '#0097a7' },
@@ -160,12 +168,30 @@ export default class Releases extends Component {
       newAuto: false,
       rowsPerPage: 15,
       page: 0,
+      isElevated: false,
     };
     this.loadReleases();
   }
 
   componentDidMount() {
     this._isMounted = true;
+
+    const { app, accountInfo } = this.props;
+
+    // If this is a production app, check for the elevated_access role to determine
+    // whether or not to enable creating arbitrary builds
+
+    // There is still an API call on the backend that controls access to the actual
+    // creation of a build, this is merely for convienence.
+
+    let isElevated = false;
+    if (app.space.compliance.includes('prod') || app.space.compliance.includes('socs')) {
+      // If we don't have the elevated_access object in the accountInfo object,
+      // default to enabling the button (access will be controlled on the API)
+      isElevated = accountInfo.elevated_access ? accountInfo.elevated_access : true;
+    }
+
+    this.setState({ isElevated }); // eslint-disable-line react/no-did-mount-set-state
   }
   componentWillUnmount() {
     this._isMounted = false;
@@ -251,10 +277,10 @@ export default class Releases extends Component {
 
   loadReleases() {
     return new Promise((resolve) => {
-      api.getApp(this.props.app).then(() => {
-        api.getBuilds(this.props.app).then((buildResponse) => {
+      api.getApp(this.props.app.name).then(() => {
+        api.getBuilds(this.props.app.name).then((buildResponse) => {
           let builds = buildResponse.data;
-          api.getReleases(this.props.app).then((releaseResponse) => {
+          api.getReleases(this.props.app.name).then((releaseResponse) => {
             const releases = releaseResponse
               .sort((a, b) => (
                 new Date(a.created_at).getTime() > new Date(b.created_at).getTime() ? 1 : -1
@@ -306,7 +332,7 @@ export default class Releases extends Component {
 
   handleRevertGo() {
     api.createRelease(
-      this.props.app,
+      this.props.app.name,
       null,
       this.state.revert.id,
       `Rollback to release v${this.state.revert.version}`,
@@ -382,7 +408,7 @@ export default class Releases extends Component {
   }
 
   render() {
-    const { releases, rowsPerPage, page } = this.state;
+    const { releases, rowsPerPage, page, isElevated } = this.state;
     const actions = [
       <IconButton style={style.iconButton} onClick={() => { this.handleClose(); }}>
         <RemoveIcon />
@@ -400,6 +426,28 @@ export default class Releases extends Component {
         onClick={() => { this.handleRevertClose(); }}
       >Cancel</Button>,
     ];
+
+    let newReleaseButton;
+    if (isElevated) {
+      newReleaseButton = (
+        <Tooltip title="New Release" placement="bottom-end">
+          <IconButton style={style.iconButton} className="new-build" onClick={() => { this.handleNewBuild(); }}><AddIcon /></IconButton>
+        </Tooltip>
+      );
+    } else {
+      // Wrap the new release button in a tooltip to avoid confusion as to why it is disabled
+      newReleaseButton = addRestrictedTooltip('Elevated access required', 'right', (
+        <IconButton
+          disabled
+          style={{ ...style.iconButton, opacity: 0.35 }}
+          className="new-build"
+          onClick={() => { this.handleNewBuild(); }}
+        >
+          <AddIcon />
+        </IconButton>
+      ));
+    }
+
     if (this.state.loading) {
       return (
         <MuiThemeProvider theme={muiTheme}>
@@ -421,7 +469,7 @@ export default class Releases extends Component {
               <DialogContent style={{ padding: '0px', margin: '0px' }}>
                 <Logs
                   build={this.state.release.slug.id}
-                  app={this.props.app}
+                  app={this.props.app.name}
                   open={this.state.logsOpen}
                 />
               </DialogContent>
@@ -453,16 +501,14 @@ export default class Releases extends Component {
               <Tooltip title="Attach to Repo" placement="bottom-end">
                 <IconButton style={style.iconButton} className="new-autobuild" onClick={() => { this.handleNewAutoBuild(); }}><AutoBuildIcon /></IconButton>
               </Tooltip>
-              <Tooltip title="New Release" placement="bottom-end">
-                <IconButton style={style.iconButton} className="new-build" onClick={() => { this.handleNewBuild(); }}><AddIcon /></IconButton>
-              </Tooltip>
+              {newReleaseButton}
             </Paper>
           )}
           {this.state.new && (
             <div>
               <IconButton style={style.iconButton} className="build-cancel" onClick={() => { this.handleNewBuildCancel(); }}><RemoveIcon /></IconButton>
               <NewBuild
-                app={this.props.app}
+                app={this.props.app.name}
                 org={this.props.org}
                 onComplete={
                   (message) => { this.reload(message); }
@@ -474,7 +520,7 @@ export default class Releases extends Component {
             <div>
               <IconButton style={style.iconButton} className="auto-cancel" onClick={() => { this.handleNewAutoBuildCancel(); }}><RemoveIcon /></IconButton>
               <NewAutoBuild
-                app={this.props.app}
+                app={this.props.app.name}
                 onComplete={(message) => { this.reload(message); }}
               />
             </div>
@@ -513,6 +559,7 @@ export default class Releases extends Component {
 }
 
 Releases.propTypes = {
-  app: PropTypes.string.isRequired,
+  app: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  accountInfo: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   org: PropTypes.string.isRequired,
 };

--- a/src/components/Releases/index.jsx
+++ b/src/components/Releases/index.jsx
@@ -169,6 +169,7 @@ export default class Releases extends Component {
       rowsPerPage: 15,
       page: 0,
       isElevated: false,
+      restrictedSpace: false,
     };
     this.loadReleases();
   }
@@ -184,14 +185,16 @@ export default class Releases extends Component {
     // There is still an API call on the backend that controls access to the actual
     // creation of a build, this is merely for convienence.
 
-    let isElevated = true;
+    let isElevated = false;
+    let restrictedSpace = false;
     if (app.space.compliance.includes('prod') || app.space.compliance.includes('socs')) {
       // If we don't have the elevated_access object in the accountInfo object,
       // default to enabling the button (access will be controlled on the API)
       isElevated = accountInfo.elevated_access ? accountInfo.elevated_access : true;
+      restrictedSpace = true;
     }
 
-    this.setState({ isElevated }); // eslint-disable-line react/no-did-mount-set-state
+    this.setState({ isElevated, restrictedSpace }); // eslint-disable-line react/no-did-mount-set-state
   }
   componentWillUnmount() {
     this._isMounted = false;
@@ -408,7 +411,7 @@ export default class Releases extends Component {
   }
 
   render() {
-    const { releases, rowsPerPage, page, isElevated } = this.state;
+    const { releases, rowsPerPage, page, isElevated, restrictedSpace } = this.state;
     const actions = [
       <IconButton style={style.iconButton} onClick={() => { this.handleClose(); }}>
         <RemoveIcon />
@@ -428,7 +431,7 @@ export default class Releases extends Component {
     ];
 
     let newReleaseButton;
-    if (isElevated) {
+    if (!restrictedSpace || isElevated) {
       newReleaseButton = (
         <Tooltip title="New Release" placement="bottom-end">
           <IconButton style={style.iconButton} className="new-build" onClick={() => { this.handleNewBuild(); }}><AddIcon /></IconButton>

--- a/src/components/Releases/index.jsx
+++ b/src/components/Releases/index.jsx
@@ -184,7 +184,7 @@ export default class Releases extends Component {
     // There is still an API call on the backend that controls access to the actual
     // creation of a build, this is merely for convienence.
 
-    let isElevated = false;
+    let isElevated = true;
     if (app.space.compliance.includes('prod') || app.space.compliance.includes('socs')) {
       // If we don't have the elevated_access object in the accountInfo object,
       // default to enabling the button (access will be controlled on the API)

--- a/src/scenes/Apps/AppInfo.jsx
+++ b/src/scenes/Apps/AppInfo.jsx
@@ -103,6 +103,7 @@ export default class AppInfo extends Component {
     super(props);
     this.state = {
       app: {},
+      accountInfo: {},
       loading: true,
       submitMessage: '',
       submitFail: false,
@@ -123,10 +124,13 @@ export default class AppInfo extends Component {
         currentTab = 'info';
         window.location.hash = `${this.state.baseHash}info`;
       }
-      this.setState({ currentTab });
-      this.setState({
-        app: response.data,
-        loading: false,
+      api.getAccount().then((response2) => {
+        this.setState({
+          currentTab,
+          app: response.data,
+          accountInfo: response2.data,
+          loading: false,
+        });
       });
     }).catch((error) => {
       this.setState({
@@ -325,7 +329,7 @@ export default class AppInfo extends Component {
               />
             </Tabs>
             {currentTab === 'info' && (
-              <AppOverview app={this.state.app} onComplete={this.reload} />
+              <AppOverview app={this.state.app} onComplete={this.reload} accountInfo={this.state.accountInfo} />
             )}
             {currentTab === 'dynos' && (
               <Formations

--- a/src/scenes/Apps/AppInfo.jsx
+++ b/src/scenes/Apps/AppInfo.jsx
@@ -188,19 +188,33 @@ export default class AppInfo extends Component {
   }
 
   render() {
-    const { currentTab } = this.state;
-    if (this.state.loading) {
+    const { currentTab, loading, submitMessage, submitFail } = this.state;
+    if (loading) {
+      let notFoundMessage;
+      if (submitFail) {
+        // Format the invalid application name in bold.
+        try {
+          const result = /(The specified application )(.*)( does not exist\.)/g.exec(submitMessage);
+          notFoundMessage = (
+            <span>
+              <span>{result[1]}</span>
+              <span style={{ fontWeight: 'bold' }}>{result[2]}</span>
+              <span>{result[3]}</span>
+            </span>
+          );
+        } catch (e) { notFoundMessage = submitMessage; }
+      }
       return (
         <MuiThemeProvider theme={muiTheme}>
           <div style={style.refresh.div}>
-            <CircularProgress top={0} size={40} left={0} style={style.refresh.indicator} status="loading" />
+            { !submitFail && <CircularProgress top={0} size={40} left={0} style={style.refresh.indicator} status="loading" /> }
             <Dialog
               className="not-found-error"
-              open={this.state.submitFail}
+              open={submitFail}
             >
               <DialogTitle>Error</DialogTitle>
               <DialogContent>
-                <DialogContentText>{this.state.submitMessage}</DialogContentText>
+                <DialogContentText>{notFoundMessage}</DialogContentText>
               </DialogContent>
               <DialogActions>
                 <Button

--- a/src/scenes/Apps/AppInfo.jsx
+++ b/src/scenes/Apps/AppInfo.jsx
@@ -116,28 +116,20 @@ export default class AppInfo extends Component {
   }
 
 
-  componentDidMount() {
-    api.getApp(this.props.match.params.app).then((response) => {
+  async componentDidMount() {
+    try {
+      const appResponse = await api.getApp(this.props.match.params.app);
+      const accountResponse = await api.getAccount();
       const hashPath = window.location.hash;
       let currentTab = hashPath.replace(this.state.baseHash, '');
       if (!tabs.includes(currentTab)) {
         currentTab = 'info';
         window.location.hash = `${this.state.baseHash}info`;
       }
-      api.getAccount().then((response2) => {
-        this.setState({
-          currentTab,
-          app: response.data,
-          accountInfo: response2.data,
-          loading: false,
-        });
-      });
-    }).catch((error) => {
-      this.setState({
-        submitMessage: error.response.data,
-        submitFail: true,
-      });
-    });
+      this.setState({ currentTab, app: appResponse.data, accountInfo: accountResponse.data, loading: false });
+    } catch (err) {
+      this.setState({ submitMessage: err.response.data, submitFail: true });
+    }
   }
 
   componentDidUpdate(prevProps) {

--- a/src/scenes/Apps/AppInfo.jsx
+++ b/src/scenes/Apps/AppInfo.jsx
@@ -220,6 +220,8 @@ export default class AppInfo extends Component {
                 <Button
                   onClick={this.handleNotFoundClose}
                   color="primary"
+                  autoFocus
+                  onKeyDown={e => ['Escape', 'Esc'].includes(e.key) && this.handleNotFoundClose()}
                 >
                   Ok
                 </Button>

--- a/src/scenes/Apps/AppInfo.jsx
+++ b/src/scenes/Apps/AppInfo.jsx
@@ -329,7 +329,11 @@ export default class AppInfo extends Component {
               />
             </Tabs>
             {currentTab === 'info' && (
-              <AppOverview app={this.state.app} onComplete={this.reload} accountInfo={this.state.accountInfo} />
+              <AppOverview
+                app={this.state.app}
+                onComplete={this.reload}
+                accountInfo={this.state.accountInfo}
+              />
             )}
             {currentTab === 'dynos' && (
               <Formations
@@ -338,13 +342,15 @@ export default class AppInfo extends Component {
             )}
             {currentTab === 'releases' && (
               <Releases
-                app={this.state.app.name}
+                app={this.state.app}
                 org={this.state.app.organization.name}
+                accountInfo={this.state.accountInfo}
               />
             )}
             {currentTab === 'addons' && (
               <Addons
-                app={this.state.app.name}
+                app={this.state.app}
+                accountInfo={this.state.accountInfo}
               />
             )}
             {currentTab === 'webhooks' && (

--- a/src/services/api/index.js
+++ b/src/services/api/index.js
@@ -302,6 +302,10 @@ function getUser() {
   return axios.get('/account/user');
 }
 
+function getAccount() {
+  return axios.get('/api/account');
+}
+
 function getLogSession(app) {
   return axios.post(`/api/apps/${app}/log-sessions`, { lines: 10, tail: true });
 }
@@ -446,5 +450,6 @@ export default {
   createWebHook,
   getWebhookResults,
   getAppsAttachedToAddon,
-  getAddon
+  getAddon,
+  getAccount,
 };


### PR DESCRIPTION
If user is in prod space & does not have elevated_access role, disable arbitrary build button and the delete button for apps and addons/attachments. Actual access is still controlled through the API, this is just for convenience/UX.

When app is not found, emphasize search term, autofocus on OK button, and enable ESC key to close dialog.

See [akkeris-api PR COBRA-2183](https://github.com/octanner/akkeris-api/pull/6) for the elevated_access var from the /account endpoint 

(Commit history is a bit hairy due to a rebase)