### PR TITLE
Global Search

### DIFF
--- a/src/components/CustomSelect.jsx
+++ b/src/components/CustomSelect.jsx
@@ -68,7 +68,7 @@ class CustomSelect extends PureComponent {
 
 CustomSelect.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
-  value: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  value: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired, // eslint-disable-line
   style: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   onChange: PropTypes.func.isRequired,
   name: PropTypes.string.isRequired,

--- a/src/components/GlobalSearch.jsx
+++ b/src/components/GlobalSearch.jsx
@@ -175,6 +175,14 @@ class GlobalSearch extends Component {
     api.notify.add({ name: 'globalSearch', cb: () => setTimeout(() => this.getOptions(), 2000) });
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    const { value } = this.state;
+    const path = window.location.pathname;
+    if ((!path.includes(value.label) && !path.includes(value.value)) && prevState.value === value) {
+      this.setState({ value: {} }); // eslint-disable-line react/no-did-update-set-state
+    }
+  }
+
   componentWillUnmount() {
     api.notify.remove('globalSearch');
   }

--- a/src/components/GlobalSearch.jsx
+++ b/src/components/GlobalSearch.jsx
@@ -184,6 +184,10 @@ class GlobalSearch extends Component {
     const { data: pipelines } = await api.getPipelines();
     const { data: sites } = await api.getSites();
 
+    apps.sort((a, b) => a.name.replace(/[-]/g, '').toLowerCase().localeCompare(b.name.replace(/[-]/g, '').toLowerCase()));
+    pipelines.sort((a, b) => a.name.replace(/[-]/g, '').toLowerCase().localeCompare(b.name.replace(/[-]/g, '').toLowerCase()));
+    sites.sort((a, b) => a.domain.replace(/[-._]/g, '').toLowerCase().localeCompare(b.domain.replace(/[-._]/g, '').toLowerCase()));
+
     this.setState({
       options: [
         {

--- a/src/components/GlobalSearch.jsx
+++ b/src/components/GlobalSearch.jsx
@@ -1,0 +1,287 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import AsyncSearch from 'react-select/lib/Async';
+import {
+  NoSsr, Typography, TextField, MenuItem, Paper, Divider, InputAdornment,
+} from '@material-ui/core';
+import SearchIcon from '@material-ui/icons/Search';
+import { withStyles } from '@material-ui/core/styles';
+import api from '../services/api';
+
+const styles = theme => ({
+  rootBase: {
+    backgroundColor: 'white',
+    display: 'flex',
+    alignItems: 'center',
+    padding: '2px 4px',
+    marginRight: '48px',
+    borderRadius: '18px',
+    transition: 'all 0.2s ease',
+  },
+  rootSm: { width: '250px' },
+  rootLg: { width: '350px' },
+  container: {
+    flexGrow: 1,
+  },
+  input: {
+    display: 'flex',
+    padding: 0,
+  },
+  valueContainer: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    flex: 1,
+    alignItems: 'center',
+    overflow: 'hidden',
+  },
+  noOptionsMessage: {
+    padding: `${theme.spacing.unit}px ${theme.spacing.unit * 2}px`,
+  },
+  singleValue: {
+    fontSize: 16,
+  },
+  placeholder: {
+    position: 'absolute',
+    left: 40,
+    fontSize: 16,
+  },
+  paper: {
+    position: 'absolute',
+    width: '98%',
+    zIndex: 1,
+    left: 0,
+    right: 0,
+    margin: '0 auto',
+  },
+  divider: {
+    height: theme.spacing.unit * 2,
+  },
+  headingContainer: {
+    marginLeft: '12px',
+    marginRight: '12px',
+  },
+  groupHeading: {
+    marginBottom: '6px',
+  },
+  searchIcon: {
+    marginLeft: '6px',
+  },
+});
+
+const isEmpty = obj => (obj && obj.constructor === Object && Object.entries(obj).length === 0);
+
+const inputComponent = ({ inputRef, ...props }) => <div ref={inputRef} {...props} />;
+
+const Control = props => (
+  <TextField
+    fullWidth
+    InputProps={{
+      disableUnderline: true,
+      inputComponent,
+      inputProps: {
+        className: `${props.selectProps.classes.input} select-textfield`,
+        inputRef: props.inputRef,
+        children: props.children,
+        ...props.innerProps,
+      },
+      startAdornment: (
+        <InputAdornment position="start">
+          <SearchIcon className={props.selectProps.classes.searchIcon} nativeColor="#3c4146" />
+        </InputAdornment>
+      ),
+    }}
+    {...props.selectProps.textFieldProps}
+  />
+);
+
+const Menu = props => (
+  <Paper square className={props.selectProps.classes.paper} {...props.innerProps}>
+    {props.children}
+  </Paper>
+);
+
+const NoOptionsMessage = props => (
+  <Typography
+    color="textSecondary"
+    className={props.selectProps.classes.noOptionsMessage}
+    {...props.innerProps}
+  >
+    {props.children}
+  </Typography>
+);
+
+const Option = props => (
+  <MenuItem
+    buttonRef={props.innerRef}
+    selected={props.isFocused}
+    component="div"
+    style={{ fontWeight: props.isSelected ? 500 : 400 }}
+    {...props.innerProps}
+  >
+    {props.children}
+  </MenuItem>
+);
+
+const GroupHeading = props => (
+  <div className={props.selectProps.classes.headingContainer}>
+    <Typography
+      color="textSecondary"
+      className={props.selectProps.classes.groupHeading}
+      {...props.innerProps}
+    >
+      {props.children}
+    </Typography>
+    <Divider />
+  </div>
+);
+
+const Placeholder = props => (
+  <Typography
+    color="textSecondary"
+    className={props.selectProps.classes.placeholder}
+    {...props.innerProps}
+  >
+    {props.children}
+  </Typography>
+);
+
+const SingleValue = props => (
+  <Typography
+    className={props.selectProps.classes.singleValue}
+    {...props.innerProps}
+  >
+    {props.children}
+  </Typography>
+);
+
+const ValueContainer = props => (
+  <div className={props.selectProps.classes.valueContainer}>{props.children}</div>  // eslint-disable-line
+);
+
+const components = {
+  Control, Menu, NoOptionsMessage, Option, SingleValue, ValueContainer, Placeholder, GroupHeading,
+};
+
+let timer = null;
+
+class GlobalSearch extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { options: [], value: {}, focused: false };
+  }
+
+  componentDidMount() {
+    this.getOptions();
+    api.notify.add({ name: 'globalSearch', cb: () => setTimeout(() => this.getOptions(), 2000) });
+  }
+
+  componentWillUnmount() {
+    api.notify.remove('globalSearch');
+  }
+
+  getOptions = async () => {
+    const { data: apps } = await api.getApps();
+    const { data: pipelines } = await api.getPipelines();
+    const { data: sites } = await api.getSites();
+
+    this.setState({
+      options: [
+        {
+          label: 'Apps',
+          options: apps.map(app => ({ value: app.name, label: app.name, uri: `/apps/${app.name}/info` })),
+        },
+        {
+          label: 'Pipelines',
+          options: pipelines.map(pipe => ({ value: pipe.id, label: pipe.name, uri: `/pipelines/${pipe.id}/review` })),
+        },
+        {
+          label: 'Sites',
+          options: sites.map(site => ({ value: site.id, label: site.domain, uri: `/sites/${site.id}/info` })),
+        },
+      ],
+    });
+  }
+
+  focusChanged = () => this.setState({ focused: !this.state.focused });
+
+  filter = input => option => option.label.toLowerCase().indexOf(input.toLowerCase()) > -1;
+
+  // Search after 300ms so that we don't do unnecessary filtering while the user is typing
+  // Return only the first 'maxOptions' results so the list doesn't get unnecessarily long
+  search = (input, cb) => {
+    clearTimeout(timer);
+    const { options } = this.state;
+    const maxOptions = 10;
+    if (!options || options.length !== 3) { cb([]); } else {
+      timer = setTimeout(() => {
+        const results = [
+          {
+            label: 'Apps',
+            options: options[0].options.filter(this.filter(input)).slice(0, maxOptions),
+          },
+          {
+            label: 'Pipelines',
+            options: options[1].options.filter(this.filter(input)).slice(0, maxOptions),
+          },
+          {
+            label: 'Sites',
+            options: options[2].options.filter(this.filter(input)).slice(0, maxOptions),
+          },
+        ];
+        cb(results);
+      }, 300);
+    }
+  }
+
+  render() {
+    const { onSearch, classes, theme } = this.props;
+    const { value } = this.state;
+
+    const selectStyles = {
+      input: base => ({
+        ...base,
+        color: theme.palette.text.primary,
+        '& input': {
+          font: 'inherit',
+        },
+      }),
+    };
+
+    return (
+      <div
+        className={`${classes.rootBase} ${(!this.state.focused && isEmpty(value)) ? classes.rootSm : classes.rootLg}`}
+        onBlur={this.focusChanged}
+        onFocus={this.focusChanged}
+      >
+        <NoSsr>
+          <div className={classes.container}>
+            <AsyncSearch
+              loadOptions={this.search}
+              defaultOptions
+              classes={classes}
+              styles={selectStyles}
+              components={components}
+              value={isEmpty(value) ? '' : value}
+              onChange={(inputValue) => {
+                this.setState({ value: inputValue });
+                onSearch(inputValue);
+              }}
+              placeholder="Search"
+              noOptionsMessage={({ inputValue }) => (inputValue.length > 0 ? 'No results' : 'Start typing...')}
+            />
+          </div>
+        </NoSsr>
+      </div>
+    );
+  }
+}
+
+/* eslint-disable */
+GlobalSearch.propTypes = {
+  onSearch: PropTypes.func.isRequired,
+  classes: PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired,
+};
+/* eslint-enable */
+
+export default withStyles(styles, { withTheme: true })(GlobalSearch);

--- a/src/components/GlobalSearch.jsx
+++ b/src/components/GlobalSearch.jsx
@@ -93,13 +93,14 @@ const inputComponent = ({ inputRef, ...props }) => <div ref={inputRef} {...props
 
 const Control = props => (
   <TextField
+    className="global-search"
     fullWidth
     InputProps={{
       disableUnderline: true,
       inputComponent,
       className: props.selectProps.classes.Input,
       inputProps: {
-        className: `${props.selectProps.classes.input} select-textfield`,
+        className: `${props.selectProps.classes.input}`,
         inputRef: props.inputRef,
         children: props.children,
         ...props.innerProps,
@@ -115,7 +116,7 @@ const Control = props => (
 );
 
 const Menu = props => (
-  <Paper square className={props.selectProps.classes.paper} {...props.innerProps}>
+  <Paper square className={`${props.selectProps.classes.paper} global-search-results`} {...props.innerProps}>
     {props.children}
   </Paper>
 );
@@ -143,7 +144,7 @@ const Option = props => (
 );
 
 const GroupHeading = props => (
-  <div className={props.selectProps.classes.headingContainer}>
+  <div className={`${props.selectProps.classes.headingContainer} group-heading`}>
     <Typography
       color="textSecondary"
       className={props.selectProps.classes.groupHeading}
@@ -268,21 +269,21 @@ class GlobalSearch extends Component {
   search = (input, cb) => {
     clearTimeout(timer);
     const { options } = this.state;
-    const maxOptions = 10;
+    const { maxResults } = this.props;
     if (!options || options.length !== 3) { cb([]); } else {
       timer = setTimeout(() => {
         const results = [
           {
             label: 'Apps',
-            options: options[0].options.filter(this.filter(input)).slice(0, maxOptions),
+            options: options[0].options.filter(this.filter(input)).slice(0, maxResults),
           },
           {
             label: 'Pipelines',
-            options: options[1].options.filter(this.filter(input)).slice(0, maxOptions),
+            options: options[1].options.filter(this.filter(input)).slice(0, maxResults),
           },
           {
             label: 'Sites',
-            options: options[2].options.filter(this.filter(input)).slice(0, maxOptions),
+            options: options[2].options.filter(this.filter(input)).slice(0, maxResults),
           },
         ];
         cb(this.orderResults(results));
@@ -343,9 +344,14 @@ class GlobalSearch extends Component {
 /* eslint-disable */
 GlobalSearch.propTypes = {
   onSearch: PropTypes.func.isRequired,
+  maxResults: PropTypes.number, // Number of max results per category to show
   classes: PropTypes.object.isRequired,
   theme: PropTypes.object.isRequired,
 };
 /* eslint-enable */
+
+GlobalSearch.defaultProps = {
+  maxResults: 10,
+};
 
 export default withStyles(styles, { withTheme: true })(GlobalSearch);

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -14,11 +14,13 @@ import RouterIcon from '@material-ui/icons/Router';
 import OrgIcon from '@material-ui/icons/Face';
 import InvoiceIcon from '@material-ui/icons/CreditCard';
 import MenuIcon from '@material-ui/icons/Menu';
+import GlobalSearch from './GlobalSearch';
 
 /* eslint-disable jsx-a11y/anchor-is-valid */
 
 import AccountMenu from './AccountMenu';
 import api from '../services/api';
+import History from '../config/History';
 
 const theme = parentTheme => deepmerge(parentTheme, {
   overrides: {
@@ -98,6 +100,8 @@ export default class Nav extends Component {
     });
   };
 
+  handleSearch = ({ uri }) => History.get().push(uri);
+
   render() {
     let accountMenu = (
       <div />
@@ -132,6 +136,7 @@ export default class Nav extends Component {
                 <MenuIcon nativeColor="white" />
               </IconButton>
               {title}
+              <GlobalSearch onSearch={this.handleSearch} />
               {accountMenu}
             </Toolbar>
           </AppBar>

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -140,7 +140,7 @@ export default class Nav extends Component {
                 <MenuIcon nativeColor="white" />
               </IconButton>
               {title}
-              <GlobalSearch onSearch={this.handleSearch} />
+              <GlobalSearch onSearch={this.handleSearch} maxResults={10} />
               {accountMenu}
             </Toolbar>
           </AppBar>

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -100,7 +100,11 @@ export default class Nav extends Component {
     });
   };
 
-  handleSearch = ({ uri }) => History.get().push(uri);
+  handleSearch = (value) => {
+    if (value && value.uri) {
+      History.get().push(value.uri);
+    }
+  }
 
   render() {
     let accountMenu = (

--- a/src/config/GlobalTheme.jsx
+++ b/src/config/GlobalTheme.jsx
@@ -39,7 +39,7 @@ import { createMuiTheme } from '@material-ui/core/styles';
 
 */
 
-const GlobalTheme = () => createMuiTheme({
+const GlobalTheme = createMuiTheme({
   palette: {
     primary: { main: '#0097a7' },
     // type: 'dark',

--- a/src/config/Router.jsx
+++ b/src/config/Router.jsx
@@ -25,6 +25,10 @@ const NewApp = Loadable({
 const AppInfo = Loadable({
   loader: () => import('../scenes/Apps/AppInfo'),
   loading: Loading,
+  render(loaded, props) {
+    const Component = loaded.default;
+    return <Component {...props} key={props.match.params.app} />;
+  },
 });
 
 const AppRoutes = () => (
@@ -52,6 +56,10 @@ const Pipelines = Loadable({
 const PipelineInfo = Loadable({
   loader: () => import('../scenes/Pipelines/PipelineInfo'),
   loading: Loading,
+  render(loaded, props) {
+    const Component = loaded.default;
+    return <Component {...props} key={props.match.params.pipeline} />;
+  },
 });
 
 const PipelineRoutes = () => (
@@ -136,6 +144,10 @@ const NewSite = Loadable({
 const SiteInfo = Loadable({
   loader: () => import('../scenes/Sites/SiteInfo'),
   loading: Loading,
+  render(loaded, props) {
+    const Component = loaded.default;
+    return <Component {...props} key={props.match.params.site} />;
+  },
 });
 
 const SitesRoutes = () => (

--- a/src/scenes/Apps/AppInfo.jsx
+++ b/src/scenes/Apps/AppInfo.jsx
@@ -204,7 +204,7 @@ export default class AppInfo extends Component {
           <ConfirmationModal
             open={submitFail}
             onOk={this.handleNotFoundClose}
-            message={notFoundMessage}
+            message={notFoundMessage || ''}
             title="Error"
             className="not-found-error"
           />
@@ -223,7 +223,7 @@ export default class AppInfo extends Component {
             }
           />
           <Tabs
-            fullWidth
+            variant="fullWidth"
             value={this.state.currentTab}
             onChange={this.changeActiveTab}
             scrollButtons="off"
@@ -338,7 +338,7 @@ export default class AppInfo extends Component {
         <ConfirmationModal
           open={this.state.submitFail}
           onOk={this.handleClose}
-          message={this.state.submitMessage}
+          message={this.state.submitMessage || ''}
           title="Error"
           className="app-error"
         />

--- a/src/scenes/Apps/Apps.jsx
+++ b/src/scenes/Apps/Apps.jsx
@@ -6,7 +6,6 @@ import AddIcon from '@material-ui/icons/Add';
 import api from '../../services/api';
 import AppList from '../../components/Apps/AppList';
 import util from '../../services/util';
-import AutoSuggest from '../../components/AutoSuggest';
 import History from '../../config/History';
 import CustomSelect from '../../components/CustomSelect';
 
@@ -53,7 +52,6 @@ const style = {
     minWidth: '145px',
   },
   regionContainer: {
-    marginLeft: '30px',
     minWidth: '145px',
   },
 };
@@ -92,10 +90,6 @@ export default class Apps extends Component {
       favorites,
       loading: false,
     });
-  }
-
-  handleSearch = (searchText) => {
-    History.get().push(`/apps/${searchText}/info`);
   }
 
   handleSpaceChange = (event) => {
@@ -143,11 +137,6 @@ export default class Apps extends Component {
     return (
       <div>
         <Toolbar style={style.toolbar} disableGutters>
-          <AutoSuggest
-            data={util.filterName(this.state.filteredApps)}
-            handleSearch={this.handleSearch}
-            className="search"
-          />
           <CustomSelect
             name="region"
             value={this.state.region}

--- a/src/scenes/Dashboard/Dashboard.jsx
+++ b/src/scenes/Dashboard/Dashboard.jsx
@@ -102,7 +102,6 @@ export default class Dashboard extends Component {
       <div style={{ marginBottom: '12px' }}>
         <Card className="card" style={{ overflow: 'visible' }}>
           <Tabs
-            fullWidth
             variant="fullWidth"
             value={this.state.currentTab}
             onChange={this.changeActiveTab}

--- a/src/scenes/Orgs/Orgs.jsx
+++ b/src/scenes/Orgs/Orgs.jsx
@@ -67,9 +67,9 @@ export default class Orgs extends Component {
     this.setState({ orgs, loading: false });
   }
 
-  handleSearch = (searchText) => {
-    History.get().push(`/orgs/${searchText}`);
-  }
+  // handleSearch = (searchText) => {
+  //   // History.get().push(`/orgs/${searchText}`);
+  // }
 
   render() {
     if (this.state.loading) {
@@ -82,11 +82,11 @@ export default class Orgs extends Component {
     return (
       <div>
         <Toolbar style={style.toolbar}>
-          <AutoSuggest
+          {/* <AutoSuggest
             className="search"
             data={util.filterName(this.state.orgs)}
             handleSearch={this.handleSearch}
-          />
+          /> */}
           <Link to="/orgs/new" style={style.link}>
             <IconButton className="new-org" style={{ padding: '6px', marginBottom: '-6px' }} ><AddIcon style={{ color: 'white' }} /></IconButton>
           </Link>

--- a/src/scenes/Pipelines/PipelineInfo.jsx
+++ b/src/scenes/Pipelines/PipelineInfo.jsx
@@ -225,7 +225,7 @@ export default class PipelineInfo extends Component {
             }
           />
           <Tabs
-            fullWidth
+            variant="fullWidth"
             value={this.state.currentTab}
             onChange={this.changeActiveTab}
             scrollButtons="off"

--- a/src/scenes/Pipelines/Pipelines.jsx
+++ b/src/scenes/Pipelines/Pipelines.jsx
@@ -8,8 +8,6 @@ import RemoveIcon from '@material-ui/icons/Clear';
 
 import { NewPipeline } from '../../components/Pipelines';
 import api from '../../services/api';
-import util from '../../services/util';
-import AutoSuggest from '../../components/AutoSuggest';
 import History from '../../config/History';
 
 const style = {
@@ -98,10 +96,6 @@ class Pipelines extends Component {
     History.get().push(`/pipelines/${id}/review`);
   }
 
-  handleSearch = (searchText) => {
-    History.get().push(`/pipelines/${searchText}/review`);
-  }
-
   handleNewPipeline = () => {
     this.setState({ new: true });
   }
@@ -166,11 +160,6 @@ class Pipelines extends Component {
     return (
       <div>
         <Toolbar style={style.toolbar}>
-          <AutoSuggest
-            className="search"
-            data={util.filterName(this.state.pipelines)}
-            handleSearch={this.handleSearch}
-          />
           {!this.state.new && (
             <IconButton
               className="new-pipeline"

--- a/src/scenes/Sites/SiteInfo.jsx
+++ b/src/scenes/Sites/SiteInfo.jsx
@@ -153,7 +153,7 @@ export default class SiteInfo extends Component {
             subheader={this.state.site.region.name}
           />
           <Tabs
-            fullWidth
+            variant="fullWidth"
             value={this.state.currentTab}
             onChange={this.changeActiveTab}
             scrollButtons="off"

--- a/src/scenes/Sites/Sites.jsx
+++ b/src/scenes/Sites/Sites.jsx
@@ -8,8 +8,6 @@ import { Link } from 'react-router-dom';
 import api from '../../services/api';
 import SitesList from '../../components/Sites';
 import util from '../../services/util';
-import AutoSuggest from '../../components/AutoSuggest';
-import History from '../../config/History';
 import CustomSelect from '../../components/CustomSelect';
 
 /* eslint-disable jsx-a11y/anchor-is-valid */
@@ -55,7 +53,6 @@ const style = {
     marginBottom: '12px',
   },
   regionContainer: {
-    marginLeft: '30px',
     minWidth: '145px',
   },
 };
@@ -87,10 +84,6 @@ class Sites extends Component {
     });
   }
 
-  handleSearch = (searchText) => {
-    History.get().push(`/sites/${searchText}/info`);
-  }
-
   handleRegionChange = (event) => {
     const region = event.target.value;
     const sites = util.filterSites(this.state.sites, region);
@@ -117,11 +110,6 @@ class Sites extends Component {
     return (
       <div>
         <Toolbar style={style.toolbar} disableGutters>
-          <AutoSuggest
-            className="search"
-            data={util.filterDomain(this.state.filteredSites)}
-            handleSearch={this.handleSearch}
-          />
           <CustomSelect
             name="region"
             value={this.state.region}

--- a/src/services/api/index.js
+++ b/src/services/api/index.js
@@ -1,5 +1,19 @@
 const axios = require('axios');
 
+const notify = new class Notify {
+  constructor() {
+    this.listeners = {};
+  }
+  add(listener) {
+    if (this.listeners[listener.name]) return;
+    this.listeners[listener.name] = listener.cb;
+  }
+  remove(listenerName) {
+    delete this.listeners[listenerName];
+  }
+  send = msg => Object.values(this.listeners).forEach(l => l(msg));
+}();
+
 function getApps() {
   return axios.get('/api/apps');
 }
@@ -9,15 +23,13 @@ function getApp(app) {
 }
 
 function deleteApp(app) {
+  notify.send('app delete');
   return axios.delete(`/api/apps/${app}`);
 }
 
 function createApp(name, org, space) {
-  return axios.post('/api/apps', {
-    org,
-    name,
-    space,
-  });
+  notify.send('app create');
+  return axios.post('/api/apps', { org, name, space });
 }
 
 function appSetup(blueprint) {
@@ -261,6 +273,7 @@ function getPipelineCouplings(pipeline) {
 }
 
 function createPipeline(pipeline) {
+  notify.send('pipe create');
   return axios.post('/api/pipelines', {
     name: pipeline,
   });
@@ -295,6 +308,7 @@ function deletePipelineCoupling(coupling) {
 }
 
 function deletePipeline(pipeline) {
+  notify.send('pipe delete');
   return axios.delete(`/api/pipelines/${pipeline}`);
 }
 
@@ -347,10 +361,12 @@ function getSite(site) {
 }
 
 function deleteSite(site) {
+  notify.send('site delete');
   return axios.delete(`/api/sites/${site}`);
 }
 
 function createSite(domain, region, isInternal) {
+  notify.send('site create');
   return axios.post('/api/sites', {
     domain,
     region,
@@ -474,4 +490,5 @@ export default {
   deleteFavorite,
   createFavorite,
   getHealthcheck,
+  notify,
 };

--- a/test/e2e/apps.test.js
+++ b/test/e2e/apps.test.js
@@ -44,18 +44,29 @@ test('Should show list of apps based on filter', async (t) => { // eslint-disabl
 
 test('Should throw error on non-existent app', async (t) => { // eslint-disable-line no-undef
   await t
-    .typeText('.search input', 'merp')
-    .pressKey('enter')
+    .typeText('.global-search input', '____')
+    .wait(2000)
+    .expect(Selector('.global-search-results').innerText)
+    .contains('No results', 'Search results found when none expected')
+    .navigateTo(`${baseUrl}/apps/merp/info`)
     .expect(Selector('.not-found-error').innerText)
     .contains('The specified application merp does not exist');
 });
 
 test('Should follow search to app and see all info', async (t) => { // eslint-disable-line no-undef
   await t
-    .typeText('.search input', 'api-default')
-    .pressKey('down').pressKey('enter')
+    .typeText('.global-search input', 'api-default')
+    .wait(2000).pressKey('enter')
     .expect(Selector('.card .header').innerText)
     .contains('api-default');
+});
+
+test('Should show apps as first group in global search', async (t) => { // eslint-disable-line no-undef
+  await t
+    .typeText('.global-search input', 't')
+    .wait(2000)
+    .expect(Selector('.global-search-results .group-heading').nth(0).innerText)
+    .contains('Apps', 'List of apps not first in search results');
 });
 
 test('Should be able to create and delete an app', async (t) => { // eslint-disable-line no-undef

--- a/test/e2e/pipelines.test.js
+++ b/test/e2e/pipelines.test.js
@@ -27,16 +27,19 @@ test('Should show list of pipelines', async (t) => { // eslint-disable-line no-u
 
 test('Should throw error on non-existent pipeline', async (t) => { // eslint-disable-line no-undef
   await t
-    .typeText('.search input', 'merp')
-    .pressKey('enter')
+    .typeText('.global-search input', '____')
+    .wait(2000)
+    .expect(Selector('.global-search-results').innerText)
+    .contains('No results', 'Search results found when none expected')
+    .navigateTo(`${baseUrl}/pipelines/merp/info`)
     .expect(Selector('.not-found-error').innerText)
     .contains('The specified pipeline was not found.');
 });
 
 test('Should follow search to pipeline and see all info', async (t) => { // eslint-disable-line no-undef
   await t
-    .typeText('.search input', 'testpipeline')
-    .pressKey('enter')
+    .typeText('.global-search input', 'testpipeline')
+    .wait(2000).pressKey('enter')
     .expect(Selector('.card .header').innerText)
     .contains('testpipeline')
     .click('.review-tab')
@@ -44,6 +47,15 @@ test('Should follow search to pipeline and see all info', async (t) => { // esli
     .click('.staging-tab')
     .click('.prod-tab');
 });
+
+test('Should show pipelines as first group in global search', async (t) => { // eslint-disable-line no-undef
+  await t
+    .typeText('.global-search input', 't')
+    .wait(2000)
+    .expect(Selector('.global-search-results .group-heading').nth(0).innerText)
+    .contains('Pipelines', 'List of pipelines not first in search results');
+});
+
 
 test('Should be able to create and delete pipeline', async (t) => { // eslint-disable-line no-undef
   await t

--- a/test/e2e/sites.test.js
+++ b/test/e2e/sites.test.js
@@ -27,18 +27,29 @@ test('Should show list of sites', async (t) => { // eslint-disable-line no-undef
 
 test('Should throw error on non-existent site', async (t) => { // eslint-disable-line no-undef
   await t
-    .typeText('.search input', 'merp')
-    .pressKey('enter')
+    .typeText('.global-search input', '____')
+    .wait(2000)
+    .expect(Selector('.global-search-results').innerText)
+    .contains('No results', 'Search results found when none expected')
+    .navigateTo(`${baseUrl}/sites/merp/info`)
     .expect(Selector('.not-found-error').innerText)
     .contains('The specified site was not found.');
 });
 
 test('Should follow search to site and see all info', async (t) => { // eslint-disable-line no-undef
   await t
-    .typeText('.search input', 'testsite')
-    .pressKey('enter')
+    .typeText('.global-search input', 'testsite')
+    .wait(2000).pressKey('enter')
     .expect(Selector('.card .header').innerText)
     .contains('testsite');
+});
+
+test('Should show sites as first group in global search', async (t) => { // eslint-disable-line no-undef
+  await t
+    .typeText('.global-search input', 't')
+    .wait(2000)
+    .expect(Selector('.global-search-results .group-heading').nth(0).innerText)
+    .contains('Sites', 'List of sites not first in search results');
 });
 
 test('Should be able to create and delete site', async (t) => { // eslint-disable-line no-undef


### PR DESCRIPTION
This PR includes the following changes:
- Added global search bar on the header of every page
  - Global search can search for apps, pipelines, and sites
  - Search results grouped by type (app, pipeline, site)
  - Search result groups ordered by current route (e.g. sites come first for sites pages
  - Search bar debounced by 300ms
- Removed individual search bars on apps, pipelines, sites scenes
- Certain API calls instructs global search to re-fetch data from api (e.g. deleting an app)
- Minor tweaks/fixes